### PR TITLE
feat: add varchar max size constraints in dto fields

### DIFF
--- a/src/main/kotlin/com/umjari/server/domain/auth/dto/AuthDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/auth/dto/AuthDto.kt
@@ -3,6 +3,7 @@ package com.umjari.server.domain.auth.dto
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 
 class AuthDto {
     data class LogInRequest(
@@ -12,15 +13,20 @@ class AuthDto {
 
     data class SignUpRequest(
         @field:NotBlank
+        @field:Size(max = 255)
         val userId: String?,
         @field:NotBlank
+        @field:Size(max = 255)
         val password: String?,
         @field:NotBlank
+        @field:Size(max = 255)
         val name: String?,
         @field:NotBlank @field:Email
         val email: String?,
         @field:NotBlank
+        @field:Size(max = 255)
         val nickname: String?,
+        @field:Size(max = 255)
         val intro: String? = null,
         @field:Pattern(regexp = "^[0-9]{11}$")
         val phoneNumber: String?,

--- a/src/main/kotlin/com/umjari/server/domain/concert/dto/ConcertDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/concert/dto/ConcertDto.kt
@@ -6,19 +6,37 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
+import jakarta.validation.constraints.Size
 import java.text.SimpleDateFormat
 import java.util.*
 
 class ConcertDto {
     data class CreateConcertRequest(
-        @field:NotBlank val title: String?,
-        @field:NotNull val subtitle: String?,
-        @field:NotBlank val conductor: String?,
-        @field:NotNull val host: String?,
-        @field:NotNull val support: String?,
-        @field:NotNull val qna: String?,
-        @field:NotBlank val concertInfo: String?,
-        @field:NotBlank val posterImg: String?,
+
+        @field:NotBlank
+        @field:Size(max = 255)
+        val title: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val subtitle: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val conductor: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val host: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val support: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val qna: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val concertInfo: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val posterImg: String?,
         @field:NotBlank
         @field:Pattern(
             regexp = "^(\\d{4})-(\\d{2})-(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2})$",
@@ -29,19 +47,39 @@ class ConcertDto {
         val concertRunningTime: Int?,
         @field:NotNull @field:PositiveOrZero
         val fee: Int?,
-        @field:NotBlank val regionParent: String?,
-        @field:NotBlank val regionChild: String?,
-        @field:NotBlank val regionDetail: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionParent: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionChild: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionDetail: String?,
     )
 
     data class UpdateConcertDetailRequest(
-        @field:NotBlank val title: String?,
-        @field:NotNull val subtitle: String?,
-        @field:NotBlank val conductor: String?,
-        @field:NotNull val host: String?,
-        @field:NotNull val support: String?,
-        @field:NotNull val qna: String?,
-        @field:NotBlank val posterImg: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val title: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val subtitle: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val conductor: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val host: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val support: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val qna: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val posterImg: String?,
         @field:NotBlank
         @field:Pattern(
             regexp = "^(\\d{4})-(\\d{2})-(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2})$",
@@ -52,13 +90,21 @@ class ConcertDto {
         val concertRunningTime: Int?,
         @field:NotNull @field:PositiveOrZero
         val fee: Int?,
-        @field:NotBlank val regionParent: String?,
-        @field:NotBlank val regionChild: String?,
-        @field:NotBlank val regionDetail: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionParent: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionChild: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionDetail: String?,
     )
 
     data class UpdateConcertInfoRequest(
-        @field:NotBlank val concertInfo: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val concertInfo: String?,
     )
 
     data class ConcertDetailResponse(

--- a/src/main/kotlin/com/umjari/server/domain/concert/dto/ConcertDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/concert/dto/ConcertDto.kt
@@ -32,7 +32,6 @@ class ConcertDto {
         @field:Size(max = 255)
         val qna: String?,
         @field:NotBlank
-        @field:Size(max = 255)
         val concertInfo: String?,
         @field:NotBlank
         @field:Size(max = 255)
@@ -103,7 +102,6 @@ class ConcertDto {
 
     data class UpdateConcertInfoRequest(
         @field:NotBlank
-        @field:Size(max = 255)
         val concertInfo: String?,
     )
 

--- a/src/main/kotlin/com/umjari/server/domain/group/dto/GroupDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/group/dto/GroupDto.kt
@@ -17,7 +17,6 @@ class GroupDto {
         @field:Size(max = 255)
         val practiceTime: String?,
         @field:NotNull
-        @field:Size(max = 255)
         val audition: Boolean?,
         @field:NotNull @field:PositiveOrZero
         val membershipFee: Int?,
@@ -44,7 +43,6 @@ class GroupDto {
         @field:Size(max = 255)
         val practiceTime: String?,
         @field:NotNull
-        @field:Size(max = 255)
         val audition: Boolean?,
         @field:NotNull @field:PositiveOrZero
         val membershipFee: Int?,

--- a/src/main/kotlin/com/umjari/server/domain/group/dto/GroupDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/group/dto/GroupDto.kt
@@ -5,37 +5,62 @@ import com.umjari.server.domain.group.model.Instrument
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.PositiveOrZero
+import jakarta.validation.constraints.Size
 
 class GroupDto {
     data class CreateGroupRequest(
-        @field:NotBlank val name: String?,
-        val logo: String?,
-        @field:NotBlank val practiceTime: String?,
-        @field:NotNull val audition: Boolean?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val name: String?,
+        @field:Size(max = 255) val logo: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val practiceTime: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val audition: Boolean?,
         @field:NotNull @field:PositiveOrZero
         val membershipFee: Int?,
         @field:NotNull @field:PositiveOrZero
         val monthlyFee: Int?,
-        @field:NotBlank val regionParent: String?,
-        @field:NotBlank val regionChild: String?,
-        @field:NotBlank val regionDetail: String?,
-        val homepage: String?,
-        val detailIntro: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionParent: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionChild: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionDetail: String?,
+        @field:Size(max = 255) val homepage: String?,
+        @field:Size(max = 255) val detailIntro: String?,
     )
 
     data class UpdateGroupRequest(
-        @field:NotBlank val name: String?,
-        @field:NotBlank val practiceTime: String?,
-        @field:NotNull val audition: Boolean?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val name: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val practiceTime: String?,
+        @field:NotNull
+        @field:Size(max = 255)
+        val audition: Boolean?,
         @field:NotNull @field:PositiveOrZero
         val membershipFee: Int?,
         @field:NotNull @field:PositiveOrZero
         val monthlyFee: Int?,
-        @field:NotBlank val regionParent: String?,
-        @field:NotBlank val regionChild: String?,
-        @field:NotBlank val regionDetail: String?,
-        val homepage: String?,
-        val detailIntro: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionParent: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionChild: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val regionDetail: String?,
+        @field:Size(max = 255) val homepage: String?,
+        @field:Size(max = 255) val detailIntro: String?,
     )
 
     data class UpdateGroupRecruitDetailRequest(

--- a/src/main/kotlin/com/umjari/server/domain/group/dto/GroupRegisterDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/group/dto/GroupRegisterDto.kt
@@ -1,7 +1,5 @@
 package com.umjari.server.domain.group.dto
 
-import jakarta.validation.constraints.NotBlank
-
 class GroupRegisterDto {
     data class GroupRegisterRequest(
         val userIds: List<String>,
@@ -12,9 +10,7 @@ class GroupRegisterDto {
     )
 
     data class FailedUser(
-        @field:NotBlank
         val userId: String,
-        @field:NotBlank
         val reason: String,
     )
 }

--- a/src/main/kotlin/com/umjari/server/domain/groupqna/dto/GroupQnaDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/groupqna/dto/GroupQnaDto.kt
@@ -4,11 +4,14 @@ import com.umjari.server.domain.groupqna.model.GroupQna
 import com.umjari.server.domain.user.dto.UserDto
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 class GroupQnaDto {
     data class CreateQnaRequest(
-        @field:NotBlank val title: String?,
+        @field:NotBlank
+        @field:Size(max = 255)
+        val title: String?,
         @field:NotBlank val content: String?,
         @field:NotNull val isPrivate: Boolean?,
     )


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
Add Dto field constraints that rejects string over varchar(255) max size.

Resolves #35 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [x] (필요한 경우) 문서를 적절하게 수정했습니다.
