### PR TITLE
fix: concert dashboard query ignore cases and region parameter default

### DIFF
--- a/src/main/kotlin/com/umjari/server/domain/concert/service/ConcertService.kt
+++ b/src/main/kotlin/com/umjari/server/domain/concert/service/ConcertService.kt
@@ -81,8 +81,8 @@ class ConcertService(
         val spec = ConcertSpecification()
         startDate?.let { spec.filteredByDateStart(dateFormatter.parse(it)) }
         endDate?.let { spec.filteredByDateEnd(dateFormatter.parse(it)) }
-        regionParent?.let { spec.filteredByRegionParent(regionParent) }
-        regionChild?.let { spec.filteredByRegionChild(regionChild) }
+        regionParent?.let { if (regionParent != "전체") spec.filteredByRegionParent(regionParent) }
+        regionChild?.let { if (regionParent != "전체") spec.filteredByRegionChild(regionChild) }
         text?.let { spec.filteredByText(text) }
         val concerts = concertRepository.findAll(spec.build(), pageable)
         val concertResponses = concerts.map { ConcertDto.ConcertSimpleResponse(it) }

--- a/src/main/kotlin/com/umjari/server/domain/concert/specification/ConcertSpecification.kt
+++ b/src/main/kotlin/com/umjari/server/domain/concert/specification/ConcertSpecification.kt
@@ -47,12 +47,22 @@ class ConcertSpecification {
     fun filteredByText(text: String) {
         var textSpec = Specification<Concert> { root, _, criteriaBuilder ->
             criteriaBuilder.like(
-                root.get("title"),
-                "%$text%",
+                criteriaBuilder.upper(root.get("title")),
+                "%${text.uppercase()}%",
             )
         }
-        textSpec = textSpec.or { root, _, criteriaBuilder -> criteriaBuilder.like(root.get("subtitle"), "%$text%") }
-        textSpec = textSpec.or { root, _, criteriaBuilder -> criteriaBuilder.like(root.get("concertInfo"), "%$text%") }
+        textSpec = textSpec.or { root, _, criteriaBuilder ->
+            criteriaBuilder.like(
+                criteriaBuilder.upper(root.get("subtitle")),
+                "%${text.uppercase()}%",
+            )
+        }
+        textSpec = textSpec.or { root, _, criteriaBuilder ->
+            criteriaBuilder.like(
+                criteriaBuilder.upper(root.get("concertInfo")),
+                "%${text.uppercase()}%",
+            )
+        }
 
         spec = spec.and(textSpec)
     }


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
1. concert dashboard text query ignore cases
2. If region parameter is "전체", return whole region/

Resolves #48 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [x] (필요한 경우) 문서를 적절하게 수정했습니다.
