### PR TITLE
fix: return profile name instead nickname in open qna

### DIFF
--- a/src/main/kotlin/com/umjari/server/domain/groupqna/dto/GroupQnaDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/groupqna/dto/GroupQnaDto.kt
@@ -123,7 +123,7 @@ class GroupQnaDto {
             id = qna.id,
             title = qna.title,
             isAnonymous = qna.anonymous,
-            author = UserDto.SimpleUserDto(qna.authorId, qna.authorNickname, qna.authorProfileImage),
+            author = UserDto.SimpleUserDto(qna.authorId, qna.authorProfileName, qna.authorProfileImage),
             replyCount = qna.replyCount,
             createAt = qna.createAt!!.toString(),
             updatedAt = qna.updatedAt!!.toString(),
@@ -136,7 +136,7 @@ class GroupQnaDto {
         val anonymous: Boolean
         val nickname: String
         val authorId: Long
-        val authorNickname: String
+        val authorProfileName: String
         val authorProfileImage: String
         val replyCount: Int
         val createAt: LocalDateTime?

--- a/src/main/kotlin/com/umjari/server/domain/groupqna/repository/GroupQnaRepository.kt
+++ b/src/main/kotlin/com/umjari/server/domain/groupqna/repository/GroupQnaRepository.kt
@@ -17,7 +17,7 @@ interface GroupQnaRepository : JpaRepository<GroupQna, Long?> {
             qna.isAnonymous AS anonymous,
             qna.authorNickname AS nickname,
             author.id AS authorId,
-            author.nickname AS authorNickname,
+            author.profileName AS authorProfileName,
             author.profileImage AS authorProfileImage,
             COUNT (reply.id) AS replyCount,
             qna.createdAt AS createAt,


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
Fix jpql that select profileName instead nickname when get open qna.


## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [x] (필요한 경우) 문서를 적절하게 수정했습니다.
