### PR TITLE
fix: nullable user to retieve post api

### DIFF
--- a/src/main/kotlin/com/umjari/server/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/com/umjari/server/domain/post/controller/PostController.kt
@@ -65,7 +65,7 @@ class PostController(
     fun getCommunityPost(
         @PathVariable("board_type") boardName: String,
         @PathVariable("post_id") postId: Long,
-        @CurrentUser user: User,
+        @CurrentUser user: User?,
     ): CommunityPostDto.PostDetailResponse {
         return communityPostService.getCommunityPost(boardName, postId, user)
     }

--- a/src/main/kotlin/com/umjari/server/domain/post/dto/CommunityPostDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/post/dto/CommunityPostDto.kt
@@ -103,7 +103,7 @@ class CommunityPostDto {
         val nickname: String,
         override val replies: List<PostReplyDto.PostReplyResponse>,
     ) : PostDetailResponse() {
-        constructor(post: CommunityPost, user: User) : this(
+        constructor(post: CommunityPost, user: User?) : this(
             id = post.id,
             board = post.board.boardType,
             title = post.title,
@@ -111,7 +111,7 @@ class CommunityPostDto {
             isAnonymous = post.isAnonymous,
             createAt = post.createdAt.toString(),
             updatedAt = post.updatedAt.toString(),
-            isAuthor = post.author.id == user.id,
+            isAuthor = post.author.id == user?.id,
             nickname = post.authorNickname,
             replies = post.replies.map {
                 if (it.isAnonymous) {
@@ -125,7 +125,7 @@ class CommunityPostDto {
             },
         )
 
-        constructor(post: CommunityPost, user: User, replies: List<PostReplyDto.PostReplyResponse>) : this(
+        constructor(post: CommunityPost, replies: List<PostReplyDto.PostReplyResponse>) : this(
             id = post.id,
             board = post.board.boardType,
             title = post.title,
@@ -133,7 +133,7 @@ class CommunityPostDto {
             isAnonymous = post.isAnonymous,
             createAt = post.createdAt.toString(),
             updatedAt = post.updatedAt.toString(),
-            isAuthor = post.author.id == user.id,
+            isAuthor = true,
             nickname = post.authorNickname,
             replies = replies,
         )
@@ -151,7 +151,7 @@ class CommunityPostDto {
         val authorInfo: UserDto.SimpleUserDto,
         override val replies: List<PostReplyDto.PostReplyResponse>,
     ) : PostDetailResponse() {
-        constructor(post: CommunityPost, user: User) : this(
+        constructor(post: CommunityPost, user: User?) : this(
             id = post.id,
             board = post.board.boardType,
             title = post.title,
@@ -159,7 +159,7 @@ class CommunityPostDto {
             isAnonymous = post.isAnonymous,
             createAt = post.createdAt.toString(),
             updatedAt = post.updatedAt.toString(),
-            isAuthor = post.author.id == user.id,
+            isAuthor = post.author.id == user?.id,
             authorInfo = UserDto.SimpleUserDto(post.author),
             replies = post.replies.map {
                 if (it.isAnonymous) {
@@ -173,7 +173,7 @@ class CommunityPostDto {
             },
         )
 
-        constructor(post: CommunityPost, user: User, replies: List<PostReplyDto.PostReplyResponse>) : this(
+        constructor(post: CommunityPost, replies: List<PostReplyDto.PostReplyResponse>) : this(
             id = post.id,
             board = post.board.boardType,
             title = post.title,
@@ -181,7 +181,7 @@ class CommunityPostDto {
             isAnonymous = post.isAnonymous,
             createAt = post.createdAt.toString(),
             updatedAt = post.updatedAt.toString(),
-            isAuthor = post.author.id == user.id,
+            isAuthor = true,
             authorInfo = UserDto.SimpleUserDto(post.author),
             replies = replies,
         )

--- a/src/main/kotlin/com/umjari/server/domain/post/dto/PostReplyDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/post/dto/PostReplyDto.kt
@@ -30,14 +30,14 @@ class PostReplyDto {
         val nickname: String,
         override val isAuthor: Boolean,
     ) : PostReplyResponse() {
-        constructor(reply: CommunityPostReply, user: User) : this(
+        constructor(reply: CommunityPostReply, user: User?) : this(
             id = reply.id,
             content = reply.content,
             createAt = reply.createdAt!!.toString(),
             updatedAt = reply.updatedAt!!.toString(),
             isAnonymous = reply.isAnonymous,
             nickname = reply.authorNickname,
-            isAuthor = reply.author.id == user.id,
+            isAuthor = reply.author.id == user?.id,
         )
     }
 
@@ -50,14 +50,14 @@ class PostReplyDto {
         val authorInfo: UserDto.SimpleUserDto,
         override val isAuthor: Boolean,
     ) : PostReplyResponse() {
-        constructor(reply: CommunityPostReply, user: User) : this(
+        constructor(reply: CommunityPostReply, user: User?) : this(
             id = reply.id,
             content = reply.content,
             createAt = reply.createdAt!!.toString(),
             updatedAt = reply.updatedAt!!.toString(),
             isAnonymous = reply.isAnonymous,
             authorInfo = UserDto.SimpleUserDto(reply.author),
-            isAuthor = reply.author.id == user.id,
+            isAuthor = reply.author.id == user?.id,
         )
     }
 }

--- a/src/main/kotlin/com/umjari/server/domain/post/service/CommunityPostService.kt
+++ b/src/main/kotlin/com/umjari/server/domain/post/service/CommunityPostService.kt
@@ -35,9 +35,9 @@ class CommunityPostService(
         val postObject = communityPostRepository.save(post)
 
         return if (postObject.isAnonymous) {
-            CommunityPostDto.AnonymousPostDetailResponse(postObject, user, emptyList())
+            CommunityPostDto.AnonymousPostDetailResponse(postObject, emptyList())
         } else {
-            CommunityPostDto.NotAnonymousPostDetailResponse(postObject, user, emptyList())
+            CommunityPostDto.NotAnonymousPostDetailResponse(postObject, emptyList())
         }
     }
 
@@ -72,7 +72,7 @@ class CommunityPostService(
         communityPostRepository.delete(post)
     }
 
-    fun getCommunityPost(boardName: String, postId: Long, user: User): CommunityPostDto.PostDetailResponse {
+    fun getCommunityPost(boardName: String, postId: Long, user: User?): CommunityPostDto.PostDetailResponse {
         val post = communityPostRepository.findByBoardAndId(boardNameToBoardType(boardName), postId)
             ?: throw PostIdNotFoundException(postId)
 

--- a/src/test/kotlin/com/umjari/server/domain/post/CommunityPostTests.kt
+++ b/src/test/kotlin/com/umjari/server/domain/post/CommunityPostTests.kt
@@ -231,6 +231,41 @@ class CommunityPostTests {
         )
 
         mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/1/")
+                .header("Authorization", userToken2),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.nickname").exists(),
+        ).andExpect(
+            jsonPath("$.isAuthor").value(false),
+        )
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/2/")
+                .header("Authorization", userToken2),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.isAuthor").value(false),
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/1/"),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.isAuthor").value(false),
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/2/"),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.isAuthor").value(false),
+        )
+
+        mockMvc.perform(
             MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/100/")
                 .header("Authorization", userToken1),
         ).andExpect(
@@ -250,6 +285,31 @@ class CommunityPostTests {
             jsonPath("$.contents.length()").value(2),
         ).andExpect(
             jsonPath("$.contents[1].replyCount").value(2),
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/")
+                .header("Authorization", userToken2),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.contents.length()").value(2),
+        ).andExpect(
+            jsonPath("$.contents[0].isAuthor").value(false),
+        ).andExpect(
+            jsonPath("$.contents[1].isAuthor").value(false),
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/"),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.contents.length()").value(2),
+        ).andExpect(
+            jsonPath("$.contents[0].isAuthor").value(false),
+        ).andExpect(
+            jsonPath("$.contents[1].isAuthor").value(false),
         )
 
         mockMvc.perform(


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
Nullable for user when retrieve post.

Resolves #147 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [x] (필요한 경우) 문서를 적절하게 수정했습니다.
