### PR TITLE
fix: retrieve deleted reply

### DIFF
--- a/src/main/kotlin/com/umjari/server/domain/post/dto/PostReplyDto.kt
+++ b/src/main/kotlin/com/umjari/server/domain/post/dto/PostReplyDto.kt
@@ -19,6 +19,7 @@ class PostReplyDto {
         abstract val updatedAt: String
         abstract val isAnonymous: Boolean
         abstract val isAuthor: Boolean
+        abstract val isDeleted: Boolean
     }
 
     data class AnonymousPostReplyResponse(
@@ -29,15 +30,17 @@ class PostReplyDto {
         override val isAnonymous: Boolean,
         val nickname: String,
         override val isAuthor: Boolean,
+        override val isDeleted: Boolean,
     ) : PostReplyResponse() {
         constructor(reply: CommunityPostReply, user: User?) : this(
             id = reply.id,
-            content = reply.content,
+            content = if (reply.isDeleted) "삭제된 댓글입니다." else reply.content,
             createAt = reply.createdAt!!.toString(),
             updatedAt = reply.updatedAt!!.toString(),
             isAnonymous = reply.isAnonymous,
             nickname = reply.authorNickname,
             isAuthor = reply.author.id == user?.id,
+            isDeleted = reply.isDeleted,
         )
     }
 
@@ -49,15 +52,17 @@ class PostReplyDto {
         override val isAnonymous: Boolean,
         val authorInfo: UserDto.SimpleUserDto,
         override val isAuthor: Boolean,
+        override val isDeleted: Boolean,
     ) : PostReplyResponse() {
         constructor(reply: CommunityPostReply, user: User?) : this(
             id = reply.id,
-            content = reply.content,
+            content = if (reply.isDeleted) "삭제된 댓글입니다." else reply.content,
             createAt = reply.createdAt!!.toString(),
             updatedAt = reply.updatedAt!!.toString(),
             isAnonymous = reply.isAnonymous,
             authorInfo = UserDto.SimpleUserDto(reply.author),
             isAuthor = reply.author.id == user?.id,
+            isDeleted = reply.isDeleted,
         )
     }
 }

--- a/src/test/kotlin/com/umjari/server/domain/post/CommunityPostTests.kt
+++ b/src/test/kotlin/com/umjari/server/domain/post/CommunityPostTests.kt
@@ -388,10 +388,28 @@ class CommunityPostTests {
         assert(communityPostReplyRepository.findByIdOrNull(1)!!.isDeleted)
 
         mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/v1/board/VIOLIN/post/1/reply/3/")
+                .header("Authorization", userToken1),
+        ).andExpect(
+            status().isNoContent,
+        )
+        assert(communityPostReplyRepository.findByIdOrNull(3)!!.isDeleted)
+
+        mockMvc.perform(
             MockMvcRequestBuilders.delete("/api/v1/board/VIOLIN/post/1/reply/1/")
                 .header("Authorization", userToken2),
         ).andExpect(
             status().isForbidden,
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/board/VIOLIN/post/1/"),
+        ).andExpect(
+            status().isOk,
+        ).andExpect(
+            jsonPath("$.replies[0].isDeleted").value(true),
+        ).andExpect(
+            jsonPath("$.replies[1].isDeleted").value(true),
         )
     }
 


### PR DESCRIPTION
## PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CI / CD
- [ ] 기타 설정

## PR 설명
Return `isDeleted` field with reply response when retrieve post reply.

Resolves #149 

## 체크리스트
- [x] 작성한 코드가 프로젝트의 스타일과 맞습니다.
- [x] 수정 사항이 새로운 경고를 발생시키지 않습니다.
- [x] 기존 및 신규 단위 테스트를 통과했습니다.
- [x] (필요한 경우) 문서를 적절하게 수정했습니다.
